### PR TITLE
Call AssertFixer as an API to fix multiple test cases

### DIFF
--- a/src/main/java/eu/stamp/project/assertfixer/AssertFixerResult.java
+++ b/src/main/java/eu/stamp/project/assertfixer/AssertFixerResult.java
@@ -1,0 +1,48 @@
+package eu.stamp.project.assertfixer;
+
+import java.io.File;
+
+public class AssertFixerResult {
+    private String testClass;
+    private String testMethod;
+    private boolean success;
+    private String exceptionMessage;
+    private File patch;
+
+    public AssertFixerResult(String testClass, String testMethod) {
+        this.testClass = testClass;
+        this.testMethod = testMethod;
+    }
+
+    public String getTestClass() {
+        return testClass;
+    }
+
+    public String getTestMethod() {
+        return testMethod;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+
+    public String getExceptionMessage() {
+        return exceptionMessage;
+    }
+
+    public void setExceptionMessage(String exceptionMessage) {
+        this.exceptionMessage = exceptionMessage;
+    }
+
+    public File getPatch() {
+        return patch;
+    }
+
+    public void setPatch(File patch) {
+        this.patch = patch;
+    }
+}

--- a/src/main/java/eu/stamp/project/assertfixer/Configuration.java
+++ b/src/main/java/eu/stamp/project/assertfixer/Configuration.java
@@ -1,6 +1,8 @@
 package eu.stamp.project.assertfixer;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by Benjamin DANGLOT
@@ -15,6 +17,7 @@ public class Configuration {
     private String pathToTestFolder;
     private boolean verbose;
     private String output;
+    private Map<String, List<String>> multipleTestCases;
 
     public String getSourceOutputDirectory() {
         return this.output + "/spooned";
@@ -78,5 +81,13 @@ public class Configuration {
 
     public void setOutput(String output) {
         this.output = output;
+    }
+
+    public Map<String, List<String>> getMultipleTestCases() {
+        return multipleTestCases;
+    }
+
+    public void setMultipleTestCases(Map<String, List<String>> multipleTestCases) {
+        this.multipleTestCases = new HashMap<>(multipleTestCases);
     }
 }

--- a/src/main/java/eu/stamp/project/assertfixer/Configuration.java
+++ b/src/main/java/eu/stamp/project/assertfixer/Configuration.java
@@ -1,13 +1,5 @@
 package eu.stamp.project.assertfixer;
 
-import com.martiansoftware.jsap.FlaggedOption;
-import com.martiansoftware.jsap.JSAP;
-import com.martiansoftware.jsap.JSAPException;
-import com.martiansoftware.jsap.JSAPResult;
-import com.martiansoftware.jsap.Switch;
-import eu.stamp.project.assertfixer.util.Util;
-
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -16,34 +8,13 @@ import java.util.List;
  * on 20/03/18
  */
 public class Configuration {
-
-    private static final JSAP jsap = initJSAP();
-
-    public final String classpath;
-    public final String fullQualifiedFailingTestClass;
-    public final List<String> failingTestMethods;
-    public final String pathToSourceFolder;
-    public final String pathToTestFolder;
-    public final boolean verbose;
-    public final String output;
-
-    private Configuration(String [] args) {
-        final JSAPResult options = jsap.parse(args);
-        if (options.getBoolean("help")) {
-            usage();
-        }
-        this.classpath = options.getString("classpath");
-        this.fullQualifiedFailingTestClass = options.getString("testClass");
-        this.failingTestMethods = Arrays.asList(options.getString("testMethod").split(":"));
-        this.pathToSourceFolder = options.getString("sourcePath");
-        this.pathToTestFolder = options.getString("testPath");
-        this.verbose = options.getBoolean("verbose");
-        this.output = options.getString("output");
-    }
-
-    public static Configuration get(String[] args) {
-        return new Configuration(args);
-    }
+    private String classpath;
+    private String fullQualifiedFailingTestClass;
+    private List<String> failingTestMethods;
+    private String pathToSourceFolder;
+    private String pathToTestFolder;
+    private boolean verbose;
+    private String output;
 
     public String getSourceOutputDirectory() {
         return this.output + "/spooned";
@@ -53,104 +24,59 @@ public class Configuration {
         return this.output + "/spooned-classes/";
     }
 
-    private static JSAP initJSAP() {
-        JSAP jsap = new JSAP();
-
-        FlaggedOption classpath = new FlaggedOption("classpath");
-        classpath.setLongFlag("classpath");
-        classpath.setShortFlag('c');
-        classpath.setHelp("[Mandatory] Use must specify a complete classpath to execute tests on your project."
-                + Util.LINE_SEPARATOR +
-                "The classpath should be formatted according to the OS.");
-        classpath.setStringParser(JSAP.STRING_PARSER);
-        classpath.setAllowMultipleDeclarations(false);
-        classpath.setRequired(true);
-
-        FlaggedOption testClass = new FlaggedOption("testClass");
-        testClass.setLongFlag("test-class");
-        testClass.setShortFlag('t');
-        testClass.setHelp("[Mandatory] Use must specify a failing test class."
-                + Util.LINE_SEPARATOR +
-                "You must provide a full qualified name such as: my.package.example.ClassTest"
-        );
-        testClass.setStringParser(JSAP.STRING_PARSER);
-        testClass.setAllowMultipleDeclarations(false);
-        testClass.setRequired(true);
-
-        FlaggedOption testMethod = new FlaggedOption("testMethod");
-        testMethod.setLongFlag("test-method");
-        testMethod.setShortFlag('m');
-        testMethod.setHelp("[Mandatory] Use must specify at least one failing test method."
-                + Util.LINE_SEPARATOR +
-                "Separate multiple values with \":\" such as: test1:test2");
-        testMethod.setStringParser(JSAP.STRING_PARSER);
-        testMethod.setAllowMultipleDeclarations(false);
-        testMethod.setRequired(true);
-
-        FlaggedOption sourcePath = new FlaggedOption("sourcePath");
-        sourcePath.setLongFlag("source-path");
-        sourcePath.setShortFlag('s');
-        sourcePath.setHelp("[Optional] Specify the path to the source folder."
-                + Util.LINE_SEPARATOR +
-                "(default: src/main/java/)");
-        sourcePath.setStringParser(JSAP.STRING_PARSER);
-        sourcePath.setAllowMultipleDeclarations(false);
-        sourcePath.setDefault("src/main/java/");
-
-        FlaggedOption testPath = new FlaggedOption("testPath");
-        testPath.setLongFlag("test-path");
-        testPath.setShortFlag('p');
-        testPath.setHelp("[Optional] Specify the path to the test source folder."
-                + Util.LINE_SEPARATOR +
-                " (default: src/test/java/)");
-        testPath.setStringParser(JSAP.STRING_PARSER);
-        testPath.setAllowMultipleDeclarations(false);
-        testPath.setDefault("src/main/java/");
-
-        Switch verbose = new Switch("verbose");
-        verbose.setLongFlag("verbose");
-        verbose.setHelp("Enable verbose mode");
-        verbose.setDefault("false");
-
-        FlaggedOption output = new FlaggedOption("output");
-        output.setLongFlag("output");
-        output.setShortFlag('o');
-        output.setHelp("[Optional] Specify an output folder for result and temporary files"
-                + Util.LINE_SEPARATOR +
-                "(default: target/assert-fixer)");
-        output.setDefault("target/assert-fixer");
-        output.setStringParser(JSAP.STRING_PARSER);
-        output.setAllowMultipleDeclarations(false);
-
-        Switch help = new Switch("help");
-        help.setLongFlag("help");
-        help.setShortFlag('h');
-        help.setHelp("Display this help and exit");
-        help.setDefault("false");
-
-
-        try {
-            jsap.registerParameter(classpath);
-            jsap.registerParameter(testClass);
-            jsap.registerParameter(testMethod);
-            jsap.registerParameter(sourcePath);
-            jsap.registerParameter(testPath);
-            jsap.registerParameter(verbose);
-            jsap.registerParameter(output);
-            jsap.registerParameter(help);
-        } catch (JSAPException e) {
-            throw new RuntimeException(e);
-        } catch (Exception e) {
-            usage();
-        }
-
-        return jsap;
+    public String getClasspath() {
+        return classpath;
     }
 
-    private static void usage() {
-        System.err.println("                          " + jsap.getUsage());
-        System.err.println();
-        System.err.println(jsap.getHelp());
-        System.exit(1);
+    public void setClasspath(String classpath) {
+        this.classpath = classpath;
+    }
+
+    public String getFullQualifiedFailingTestClass() {
+        return fullQualifiedFailingTestClass;
+    }
+
+    public void setFullQualifiedFailingTestClass(String fullQualifiedFailingTestClass) {
+        this.fullQualifiedFailingTestClass = fullQualifiedFailingTestClass;
+    }
+
+    public List<String> getFailingTestMethods() {
+        return failingTestMethods;
+    }
+
+    public void setFailingTestMethods(List<String> failingTestMethods) {
+        this.failingTestMethods = failingTestMethods;
+    }
+
+    public String getPathToSourceFolder() {
+        return pathToSourceFolder;
+    }
+
+    public void setPathToSourceFolder(String pathToSourceFolder) {
+        this.pathToSourceFolder = pathToSourceFolder;
+    }
+
+    public String getPathToTestFolder() {
+        return pathToTestFolder;
+    }
+
+    public void setPathToTestFolder(String pathToTestFolder) {
+        this.pathToTestFolder = pathToTestFolder;
+    }
+
+    public boolean isVerbose() {
+        return verbose;
+    }
+
+    public void setVerbose(boolean verbose) {
+        this.verbose = verbose;
+    }
+
+    public String getOutput() {
+        return output;
+    }
+
+    public void setOutput(String output) {
+        this.output = output;
     }
 }

--- a/src/main/java/eu/stamp/project/assertfixer/JSAPConfiguration.java
+++ b/src/main/java/eu/stamp/project/assertfixer/JSAPConfiguration.java
@@ -1,0 +1,133 @@
+package eu.stamp.project.assertfixer;
+
+import com.martiansoftware.jsap.FlaggedOption;
+import com.martiansoftware.jsap.JSAP;
+import com.martiansoftware.jsap.JSAPException;
+import com.martiansoftware.jsap.JSAPResult;
+import com.martiansoftware.jsap.Switch;
+import eu.stamp.project.assertfixer.util.Util;
+
+import java.util.Arrays;
+
+public class JSAPConfiguration extends Configuration {
+    private static final JSAP jsap = initJSAP();
+
+    private JSAPConfiguration(String[] args) {
+        final JSAPResult options = jsap.parse(args);
+        if (options.getBoolean("help")) {
+            usage();
+        }
+        this.setClasspath(options.getString("classpath"));
+        this.setFullQualifiedFailingTestClass(options.getString("testClass"));
+        this.setFailingTestMethods(Arrays.asList(options.getString("testMethod").split(":")));
+        this.setPathToSourceFolder(options.getString("sourcePath"));
+        this.setPathToTestFolder(options.getString("testPath"));
+        this.setVerbose(options.getBoolean("verbose"));
+        this.setOutput(options.getString("output"));
+    }
+
+    public static JSAPConfiguration get(String[] args) {
+        return new JSAPConfiguration(args);
+    }
+
+    private static JSAP initJSAP() {
+        JSAP jsap = new JSAP();
+
+        FlaggedOption classpath = new FlaggedOption("classpath");
+        classpath.setLongFlag("classpath");
+        classpath.setShortFlag('c');
+        classpath.setHelp("[Mandatory] Use must specify a complete classpath to execute tests on your project."
+                + Util.LINE_SEPARATOR +
+                "The classpath should be formatted according to the OS.");
+        classpath.setStringParser(JSAP.STRING_PARSER);
+        classpath.setAllowMultipleDeclarations(false);
+        classpath.setRequired(true);
+
+        FlaggedOption testClass = new FlaggedOption("testClass");
+        testClass.setLongFlag("test-class");
+        testClass.setShortFlag('t');
+        testClass.setHelp("[Mandatory] Use must specify a failing test class."
+                + Util.LINE_SEPARATOR +
+                "You must provide a full qualified name such as: my.package.example.ClassTest"
+        );
+        testClass.setStringParser(JSAP.STRING_PARSER);
+        testClass.setAllowMultipleDeclarations(false);
+        testClass.setRequired(true);
+
+        FlaggedOption testMethod = new FlaggedOption("testMethod");
+        testMethod.setLongFlag("test-method");
+        testMethod.setShortFlag('m');
+        testMethod.setHelp("[Mandatory] Use must specify at least one failing test method."
+                + Util.LINE_SEPARATOR +
+                "Separate multiple values with \":\" such as: test1:test2");
+        testMethod.setStringParser(JSAP.STRING_PARSER);
+        testMethod.setAllowMultipleDeclarations(false);
+        testMethod.setRequired(true);
+
+        FlaggedOption sourcePath = new FlaggedOption("sourcePath");
+        sourcePath.setLongFlag("source-path");
+        sourcePath.setShortFlag('s');
+        sourcePath.setHelp("[Optional] Specify the path to the source folder."
+                + Util.LINE_SEPARATOR +
+                "(default: src/main/java/)");
+        sourcePath.setStringParser(JSAP.STRING_PARSER);
+        sourcePath.setAllowMultipleDeclarations(false);
+        sourcePath.setDefault("src/main/java/");
+
+        FlaggedOption testPath = new FlaggedOption("testPath");
+        testPath.setLongFlag("test-path");
+        testPath.setShortFlag('p');
+        testPath.setHelp("[Optional] Specify the path to the test source folder."
+                + Util.LINE_SEPARATOR +
+                " (default: src/test/java/)");
+        testPath.setStringParser(JSAP.STRING_PARSER);
+        testPath.setAllowMultipleDeclarations(false);
+        testPath.setDefault("src/main/java/");
+
+        Switch verbose = new Switch("verbose");
+        verbose.setLongFlag("verbose");
+        verbose.setHelp("Enable verbose mode");
+        verbose.setDefault("false");
+
+        FlaggedOption output = new FlaggedOption("output");
+        output.setLongFlag("output");
+        output.setShortFlag('o');
+        output.setHelp("[Optional] Specify an output folder for result and temporary files"
+                + Util.LINE_SEPARATOR +
+                "(default: target/assert-fixer)");
+        output.setDefault("target/assert-fixer");
+        output.setStringParser(JSAP.STRING_PARSER);
+        output.setAllowMultipleDeclarations(false);
+
+        Switch help = new Switch("help");
+        help.setLongFlag("help");
+        help.setShortFlag('h');
+        help.setHelp("Display this help and exit");
+        help.setDefault("false");
+
+
+        try {
+            jsap.registerParameter(classpath);
+            jsap.registerParameter(testClass);
+            jsap.registerParameter(testMethod);
+            jsap.registerParameter(sourcePath);
+            jsap.registerParameter(testPath);
+            jsap.registerParameter(verbose);
+            jsap.registerParameter(output);
+            jsap.registerParameter(help);
+        } catch (JSAPException e) {
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            usage();
+        }
+
+        return jsap;
+    }
+
+    private static void usage() {
+        System.err.println("                          " + jsap.getUsage());
+        System.err.println();
+        System.err.println(jsap.getHelp());
+        System.exit(1);
+    }
+}

--- a/src/main/java/eu/stamp/project/assertfixer/asserts/AssertFixer.java
+++ b/src/main/java/eu/stamp/project/assertfixer/asserts/AssertFixer.java
@@ -82,7 +82,7 @@ public class AssertFixer {
         if (!remove) {
             throw new RuntimeException();
         }
-        TestRunner.runTest(configuration, spoon, testCaseName);
+        TestRunner.runTest(configuration, spoon, fullQualifiedName, testCaseName);
     }
 
 }

--- a/src/main/java/eu/stamp/project/assertfixer/test/TestRunner.java
+++ b/src/main/java/eu/stamp/project/assertfixer/test/TestRunner.java
@@ -1,5 +1,6 @@
 package eu.stamp.project.assertfixer.test;
 
+import eu.stamp.project.assertfixer.Configuration;
 import eu.stamp.project.assertfixer.asserts.log.Logger;
 import eu.stamp.project.assertfixer.util.Util;
 import eu.stamp.project.testrunner.EntryPoint;
@@ -22,8 +23,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.stream.IntStream;
 
-import static eu.stamp.project.assertfixer.Main.configuration;
-
 /**
  * Created by Benjamin DANGLOT
  * benjamin.danglot@inria.fr
@@ -31,19 +30,19 @@ import static eu.stamp.project.assertfixer.Main.configuration;
  */
 public class TestRunner {
 
-    public static TestListener runTest(Launcher launcher, String failingTestMethod) {
+    public static TestListener runTest(Configuration configuration, Launcher launcher, String failingTestMethod) {
         final SpoonModelBuilder compiler = launcher.createCompiler();
         compiler.setBinaryOutputDirectory(new File(configuration.getBinaryOutputDirectory()));
         compiler.compile(SpoonModelBuilder.InputType.CTTYPES);
         return EntryPoint.runTests(
                 configuration.getBinaryOutputDirectory()
-                        + Util.PATH_SEPARATOR + configuration.classpath,
-                configuration.fullQualifiedFailingTestClass,
+                        + Util.PATH_SEPARATOR + configuration.getClasspath(),
+                configuration.getFullQualifiedFailingTestClass(),
                 failingTestMethod
         );
     }
 
-    public static void runTestWithLogger(Launcher spoon,
+    public static void runTestWithLogger(Configuration configuration, Launcher spoon,
                                          String classpath,
                                          String fullQualifiedName,
                                          String testCaseName) {

--- a/src/main/java/eu/stamp/project/assertfixer/test/TestRunner.java
+++ b/src/main/java/eu/stamp/project/assertfixer/test/TestRunner.java
@@ -30,14 +30,14 @@ import java.util.stream.IntStream;
  */
 public class TestRunner {
 
-    public static TestListener runTest(Configuration configuration, Launcher launcher, String failingTestMethod) {
+    public static TestListener runTest(Configuration configuration, Launcher launcher, String failingTestClass, String failingTestMethod) {
         final SpoonModelBuilder compiler = launcher.createCompiler();
         compiler.setBinaryOutputDirectory(new File(configuration.getBinaryOutputDirectory()));
         compiler.compile(SpoonModelBuilder.InputType.CTTYPES);
         return EntryPoint.runTests(
                 configuration.getBinaryOutputDirectory()
                         + Util.PATH_SEPARATOR + configuration.getClasspath(),
-                configuration.getFullQualifiedFailingTestClass(),
+                failingTestClass,
                 failingTestMethod
         );
     }

--- a/src/test/java/eu/stamp/project/assertfixer/AbstractTest.java
+++ b/src/test/java/eu/stamp/project/assertfixer/AbstractTest.java
@@ -19,6 +19,7 @@ import java.io.File;
 public class AbstractTest {
 
     protected static String dependenciesToRunJUnit;
+    protected static Configuration configuration;
 
     static {
         try {
@@ -44,7 +45,7 @@ public class AbstractTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        Main.configuration = Configuration.get(new String[]{
+        configuration = JSAPConfiguration.get(new String[]{
                 "--classpath", dependenciesToRunJUnit,
                 "--test-class", "aPackage.ClassResourcesTest",
                 "--test-method", "testAssertionErrorBoolean:testAssertionErrorPrimitive",

--- a/src/test/java/eu/stamp/project/assertfixer/asserts/AssertFixerTest.java
+++ b/src/test/java/eu/stamp/project/assertfixer/asserts/AssertFixerTest.java
@@ -27,7 +27,7 @@ public class AssertFixerTest extends AbstractTest {
 
         assertTrue(failures.size() == 1);
 
-        AssertFixer.fixAssert(spoon,
+        AssertFixer.fixAssert(configuration, spoon,
                 fullQualifiedName,
                 testCaseName,
                 failures.get(0),

--- a/src/test/java/eu/stamp/project/assertfixer/asserts/CommentTest.java
+++ b/src/test/java/eu/stamp/project/assertfixer/asserts/CommentTest.java
@@ -39,7 +39,7 @@ public class CommentTest extends AbstractTest {
                 fullQualifiedName,
                 testCaseName).getFailingTests();// 1st assert fail
 
-        AssertFixer.fixAssert(spoon,
+        AssertFixer.fixAssert(configuration, spoon,
                 fullQualifiedName,
                 testCaseName,
                 failures.get(0),

--- a/src/test/java/eu/stamp/project/assertfixer/util/CounterTest.java
+++ b/src/test/java/eu/stamp/project/assertfixer/util/CounterTest.java
@@ -29,7 +29,7 @@ public class CounterTest extends AbstractTest {
                 fullQualifiedName,
                 testCaseName).getFailingTests();// 1st assert fail
 
-        AssertFixer.fixAssert(spoon,
+        AssertFixer.fixAssert(configuration, spoon,
                 fullQualifiedName,
                 testCaseName,
                 failures.get(0),


### PR DESCRIPTION
The purpose of this PR is twofolds: 
  1. To be able to use AssertFixer as an external Java API and get a result (not just 0 or 1)
  2. To be able to fix at once multiple test classes of the same project

