### PR TITLE
Bump `test-runner` to `3.0.0-SNAPSHOT`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,12 @@
 
     <repositories>
       <repository>
+        <id>snapshots-repo</id>
+        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        <releases><enabled>false</enabled></releases>
+        <snapshots><enabled>true</enabled></snapshots>
+      </repository>
+      <repository>
         <id>gforge.inria.fr-release</id>
         <name>Maven Repository for Spoon Release</name>
         <url>http://maven.inria.fr/artifactory/spoon-public-snapshot/</url>
@@ -109,7 +115,7 @@
         <dependency>
             <groupId>eu.stamp-project</groupId>
             <artifactId>test-runner</artifactId>
-            <version>2.1.1</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
@@ -205,7 +211,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.5.201505241946</version>
+                <version>0.8.7</version>
                 <configuration>
                     <excludes>
                         <exclude>**/fr/inria/spirals/test4repair/*</exclude>

--- a/src/main/java/eu/stamp/project/assertfixer/Main.java
+++ b/src/main/java/eu/stamp/project/assertfixer/Main.java
@@ -100,7 +100,8 @@ public class Main {
     private AssertFixerResult fixGivenTest(Launcher launcher, String failingClass, String failingTestMethod) {
         CtClass testClass = launcher.getFactory().Class().get(failingClass);
 
-        Failure failure = TestRunner.runTest(this.configuration, launcher, failingClass, failingTestMethod).getFailingTests().get(0);
+        Failure failure = TestRunner.runTest(this.configuration, launcher, failingClass, failingTestMethod)
+                .getFailingTests().stream().findFirst().orElseThrow(RuntimeException::new);
         LOGGER.info("Fixing: {}", failure.messageOfFailure);
         return AssertFixer.fixAssert(
                     configuration,

--- a/src/test/java/eu/stamp/project/assertfixer/asserts/AssertFixerTest.java
+++ b/src/test/java/eu/stamp/project/assertfixer/asserts/AssertFixerTest.java
@@ -7,12 +7,9 @@ import eu.stamp_project.testrunner.runner.Failure;
 import org.junit.Test;
 import spoon.reflect.declaration.CtClass;
 
+import java.util.Set;
 
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Created by Benjamin DANGLOT
@@ -24,7 +21,7 @@ public class AssertFixerTest extends AbstractTest {
     private AssertFixerResult test(String testCaseName) throws Exception {
         String fullQualifiedName = "aPackage.ClassResourcesTest";
 
-        List<Failure> failures = EntryPoint.runTests(
+        Set<Failure> failures = EntryPoint.runTests(
                 getClasspath(),
                 fullQualifiedName,
                 testCaseName).getFailingTests();// 1st assert fail
@@ -34,7 +31,7 @@ public class AssertFixerTest extends AbstractTest {
         AssertFixerResult result = AssertFixer.fixAssert(configuration, spoon,
                 testClass,
                 testCaseName,
-                failures.get(0),
+                failures.stream().findFirst().get(),
                 getClasspath());
 
         assertTrue("result should have been successful " + result.getExceptionMessage(), result.isSuccess());

--- a/src/test/java/eu/stamp/project/assertfixer/util/CounterTest.java
+++ b/src/test/java/eu/stamp/project/assertfixer/util/CounterTest.java
@@ -9,7 +9,7 @@ import spoon.reflect.declaration.CtClass;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
-import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static eu.stamp.project.assertfixer.util.Util.FILE_SEPARATOR;
@@ -25,7 +25,7 @@ public class CounterTest extends AbstractTest {
 
     private void test(String testCaseName) throws Exception {
         String fullQualifiedName = "aPackage.ClassResourcesTest";
-        List<Failure> failures = EntryPoint.runTests(
+        Set<Failure> failures = EntryPoint.runTests(
                 getClasspath(),
                 fullQualifiedName,
                 testCaseName).getFailingTests();// 1st assert fail
@@ -34,7 +34,7 @@ public class CounterTest extends AbstractTest {
         AssertFixer.fixAssert(configuration, spoon,
                 testClass,
                 testCaseName,
-                failures.get(0),
+                failures.stream().findFirst().get(),
                 getClasspath());
     }
 


### PR DESCRIPTION
Bumps `test-runner`'s version to `3.0.0-SNAPSHOT` and updates its usage.

This is required since otherwise assert fixer and flacoco won't be compatible in repairnator.